### PR TITLE
remove us-east

### DIFF
--- a/ibm_catalog.json
+++ b/ibm_catalog.json
@@ -131,10 +131,6 @@
                   {
                     "displayname": "London (eu-gb)",
                     "value": "eu-gb"
-                  },
-                  {
-                    "displayname": "Washington DC (us-east)",
-                    "value": "us-east"
                   }
                 ]
               },

--- a/tests/pr_test.go
+++ b/tests/pr_test.go
@@ -39,7 +39,6 @@ var validRegions = []string{
 	"us-south",
 	"eu-gb",
 	"ca-tor",
-	"us-east",
 }
 
 func TestMain(m *testing.M) {

--- a/variables.tf
+++ b/variables.tf
@@ -22,9 +22,8 @@ variable "region" {
       var.region == "us-south",
       var.region == "eu-gb",
       var.region == "ca-tor",
-      var.region == "us-east",
     ])
-    error_message = "Region must be specified and set to one of the permitted values ('ca-tor', 'eu-gb', 'us-south', 'us-east') when provisioning a new instance."
+    error_message = "Region must be specified and set to one of the permitted values ('ca-tor', 'eu-gb', 'us-south') when provisioning a new instance."
   }
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -21,7 +21,7 @@ variable "region" {
     condition = var.existing_watsonx_orchestrate_instance_crn != null || anytrue([
       var.region == "us-south",
       var.region == "eu-gb",
-      var.region == "ca-tor",
+      var.region == "ca-tor"
     ])
     error_message = "Region must be specified and set to one of the permitted values ('ca-tor', 'eu-gb', 'us-south') when provisioning a new instance."
   }


### PR DESCRIPTION
### Description

https://github.com/terraform-ibm-modules/terraform-ibm-watsonx-orchestrate/issues/24

### Release required?
<!--- Identify the type of release. For information about the changes in a semantic versioning release, see [Release versioning](https://terraform-ibm-modules.github.io/documentation/#/versioning). --->

- [ ] No release
- [x] Patch release (`x.x.X`)
- [ ] Minor release (`x.X.x`)
- [ ] Major release (`X.x.x`)

##### Release notes content

Removed the unsupported us-east region.

### Run the pipeline

If the CI pipeline doesn't run when you create the PR, the PR requires a user with GitHub collaborators access to run the pipeline.

Run the CI pipeline when the PR is ready for review and you expect tests to pass. Add a comment to the PR with the following text:

```
/run pipeline
```

### Checklist for reviewers

- [ ] If relevant, a test for the change is included or updated with this PR.
- [ ] If relevant, documentation for the change is included or updated with this PR.

### For mergers

- Use a conventional commit message to set the release level. Follow the [guidelines](https://terraform-ibm-modules.github.io/documentation/#/merging.md).
- Include information that users need to know about the PR in the commit message. The commit message becomes part of the GitHub release notes.
- Use the **Squash and merge** option.
