### PR TITLE
updated DA to only support using existing resource group

### DIFF
--- a/ibm_catalog.json
+++ b/ibm_catalog.json
@@ -84,7 +84,7 @@
             {
               "key": "prefix",
               "required": true,
-              "description": "Prefix to add to all resources created by this solution. To not use any prefix value, you can enter the string `__NULL__`."
+              "description": "The prefix to add to all resources that this solution creates (e.g `prod`, `test`, `dev`). To not use any prefix value, you can enter the string `__NULL__`."
             },
             {
               "key": "region",

--- a/ibm_catalog.json
+++ b/ibm_catalog.json
@@ -107,7 +107,15 @@
             },
             {
               "key": "existing_resource_group_name",
-              "required": true
+              "required": true,
+              "custom_config": {
+                "type": "resource_group",
+                "grouping": "deployment",
+                "original_grouping": "deployment",
+                "config_constraints": {
+                  "identifier": "rg_name"
+                }
+              }
             },
             {
               "key": "name"

--- a/ibm_catalog.json
+++ b/ibm_catalog.json
@@ -106,11 +106,8 @@
               ]
             },
             {
-              "key": "use_existing_resource_group",
+              "key": "existing_resource_group_name",
               "required": true
-            },
-            {
-              "key": "resource_group_name"
             },
             {
               "key": "name"
@@ -163,16 +160,12 @@
               "input_mapping": [
                 {
                   "dependency_output": "workload_resource_group_name",
-                  "version_input": "resource_group_name"
+                  "version_input": "existing_resource_group_name"
                 },
                 {
                   "dependency_input": "prefix",
                   "version_input": "prefix",
                   "reference_version": true
-                },
-                {
-                  "value": true,
-                  "version_input": "use_existing_resource_group"
                 }
               ],
               "optional": true,

--- a/solutions/fully-configurable/catalogValidationValues.json.template
+++ b/solutions/fully-configurable/catalogValidationValues.json.template
@@ -3,5 +3,5 @@
   "region": "us-south",
   "resource_tags": $TAGS,
   "name": $PREFIX,
-  "resource_group_name": $PREFIX
+  "existing_resource_group_name": $PREFIX
 }

--- a/solutions/fully-configurable/catalogValidationValues.json.template
+++ b/solutions/fully-configurable/catalogValidationValues.json.template
@@ -3,5 +3,5 @@
   "region": "us-south",
   "resource_tags": $TAGS,
   "name": $PREFIX,
-  "existing_resource_group_name": $PREFIX
+  "existing_resource_group_name": "geretain-test-resources"
 }

--- a/solutions/fully-configurable/main.tf
+++ b/solutions/fully-configurable/main.tf
@@ -13,8 +13,7 @@ locals {
 module "resource_group" {
   source                       = "terraform-ibm-modules/resource-group/ibm"
   version                      = "1.1.6"
-  resource_group_name          = var.use_existing_resource_group ? null : try("${local.prefix}-${var.resource_group_name}", var.resource_group_name)
-  existing_resource_group_name = var.use_existing_resource_group ? var.resource_group_name : null
+  existing_resource_group_name = var.existing_resource_group_name
 }
 
 #######################################################################################################################

--- a/solutions/fully-configurable/variables.tf
+++ b/solutions/fully-configurable/variables.tf
@@ -27,7 +27,7 @@ variable "existing_resource_group_name" {
 variable "prefix" {
   type        = string
   nullable    = true
-  description = "(Optional) Prefix to add to all resources created by this solution. To not use any prefix value, you can set this value to `null` or an empty string."
+  description = "The prefix to add to all resources that this solution creates (e.g `prod`, `test`, `dev`). To not use any prefix value, you can set this value to `null` or an empty string."
 }
 
 variable "name" {

--- a/solutions/fully-configurable/variables.tf
+++ b/solutions/fully-configurable/variables.tf
@@ -19,15 +19,9 @@ variable "provider_visibility" {
   }
 }
 
-variable "use_existing_resource_group" {
-  type        = bool
-  description = "Whether to use an existing resource group."
-  default     = false
-}
-
-variable "resource_group_name" {
+variable "existing_resource_group_name" {
   type        = string
-  description = "The name of a new or an existing resource group to provision the watsonx Orchestrate in. If a prefix input variable is specified, the prefix is added to the name in the `<prefix>-<name>` format."
+  description = "The name of an existing resource group to provision the watsonx.orchestrate in."
 }
 
 variable "prefix" {

--- a/solutions/fully-configurable/variables.tf
+++ b/solutions/fully-configurable/variables.tf
@@ -26,8 +26,8 @@ variable "existing_resource_group_name" {
 
 variable "prefix" {
   type        = string
+  nullable    = true
   description = "(Optional) Prefix to add to all resources created by this solution. To not use any prefix value, you can set this value to `null` or an empty string."
-  default     = "dev"
 }
 
 variable "name" {

--- a/tests/pr_test.go
+++ b/tests/pr_test.go
@@ -161,7 +161,7 @@ func TestRunStandardSolution(t *testing.T) {
 	options.TerraformVars = map[string]interface{}{
 		"plan":                         "standard",
 		"provider_visibility":          "public",
-		"existing_resource_group_name": "Default",
+		"existing_resource_group_name": resourceGroup,
 		"prefix":                       options.Prefix,
 		"region":                       options.Region,
 	}
@@ -185,7 +185,7 @@ func TestRunStandardUpgradeSolution(t *testing.T) {
 	options.TerraformVars = map[string]interface{}{
 		"plan":                         "standard",
 		"provider_visibility":          "public",
-		"existing_resource_group_name": "Default",
+		"existing_resource_group_name": resourceGroup,
 		"prefix":                       options.Prefix,
 		"region":                       options.Region,
 	}

--- a/tests/pr_test.go
+++ b/tests/pr_test.go
@@ -159,11 +159,11 @@ func TestRunStandardSolution(t *testing.T) {
 	})
 
 	options.TerraformVars = map[string]interface{}{
-		"plan":                "standard",
-		"provider_visibility": "public",
-		"resource_group_name": options.Prefix,
-		"prefix":              options.Prefix,
-		"region":              options.Region,
+		"plan":                         "standard",
+		"provider_visibility":          "public",
+		"existing_resource_group_name": "Default",
+		"prefix":                       options.Prefix,
+		"region":                       options.Region,
 	}
 
 	output, err := options.RunTestConsistency()
@@ -183,11 +183,11 @@ func TestRunStandardUpgradeSolution(t *testing.T) {
 	})
 
 	options.TerraformVars = map[string]interface{}{
-		"plan":                "standard",
-		"provider_visibility": "public",
-		"resource_group_name": options.Prefix,
-		"prefix":              options.Prefix,
-		"region":              options.Region,
+		"plan":                         "standard",
+		"provider_visibility":          "public",
+		"existing_resource_group_name": "Default",
+		"prefix":                       options.Prefix,
+		"region":                       options.Region,
 	}
 
 	output, err := options.RunTestUpgrade()


### PR DESCRIPTION
### Description

issue: https://github.com/terraform-ibm-modules/terraform-ibm-watsonx-orchestrate/issues/40

### Release required?
<!--- Identify the type of release. For information about the changes in a semantic versioning release, see [Release versioning](https://terraform-ibm-modules.github.io/documentation/#/versioning). --->

- [ ] No release
- [ ] Patch release (`x.x.X`)
- [x] Minor release (`x.X.x`)
- [ ] Major release (`X.x.x`)

##### Release notes content

<!--- If a release is required, replace this text with information that users need to know about the release. Write the release notes to help users understand the changes, and include information about how to update from the previous version.

Your notes help the merger write the commit message for the PR that is published in the release notes for the module. --->

### Run the pipeline

If the CI pipeline doesn't run when you create the PR, the PR requires a user with GitHub collaborators access to run the pipeline.

Run the CI pipeline when the PR is ready for review and you expect tests to pass. Add a comment to the PR with the following text:

```
/run pipeline
```

### Checklist for reviewers

- [ ] If relevant, a test for the change is included or updated with this PR.
- [ ] If relevant, documentation for the change is included or updated with this PR.

### For mergers

- Use a conventional commit message to set the release level. Follow the [guidelines](https://terraform-ibm-modules.github.io/documentation/#/merging.md).
- Include information that users need to know about the PR in the commit message. The commit message becomes part of the GitHub release notes.
- Use the **Squash and merge** option.
