### PR TITLE
fix: Implement the workaround to fix the `dashboard_url`

### DIFF
--- a/examples/existing-instance/outputs.tf
+++ b/examples/existing-instance/outputs.tf
@@ -26,3 +26,8 @@ output "guid" {
   description = "GUID of the existing watsonx Orchestrate instance"
   value       = module.existing_watsonx_orchestrate_instance.guid
 }
+
+output "dashboard_url" {
+  description = "The dashboard URL of the watsonx Orchestrate instance."
+  value       = module.existing_watsonx_orchestrate_instance.dashboard_url
+}

--- a/main.tf
+++ b/main.tf
@@ -5,8 +5,7 @@ locals {
   watsonx_orchestrate_guid          = var.existing_watsonx_orchestrate_instance_crn != null ? data.ibm_resource_instance.existing_orchestrate_instance[0].guid : ibm_resource_instance.watsonx_orchestrate_instance[0].guid
   watsonx_orchestrate_name          = var.existing_watsonx_orchestrate_instance_crn != null ? data.ibm_resource_instance.existing_orchestrate_instance[0].resource_name : ibm_resource_instance.watsonx_orchestrate_instance[0].resource_name
   watsonx_orchestrate_plan_id       = var.existing_watsonx_orchestrate_instance_crn != null ? null : ibm_resource_instance.watsonx_orchestrate_instance[0].resource_plan_id
-  watsonx_orchestrate_dashboard_url = local.watsonx_orchestrate_crn != null ? "https://us-south.watson-orchestrate.cloud.ibm.com/home/ws?plan_id=${urlencode(local.watsonx_orchestrate_plan_id)}" : null
-
+  watsonx_orchestrate_dashboard_url = var.existing_watsonx_orchestrate_instance_crn != null ? null : "https://us-south.watson-orchestrate.cloud.ibm.com/home/ws?plan_id=${urlencode(local.watsonx_orchestrate_plan_id)}"
 }
 
 module "crn_parser" {

--- a/main.tf
+++ b/main.tf
@@ -1,11 +1,12 @@
 locals {
-  account_id                        = var.existing_watsonx_orchestrate_instance_crn != null ? module.crn_parser[0].account_id : ibm_resource_instance.watsonx_orchestrate_instance[0].account_id
-  watsonx_orchestrate_id            = var.existing_watsonx_orchestrate_instance_crn != null ? data.ibm_resource_instance.existing_orchestrate_instance[0].id : ibm_resource_instance.watsonx_orchestrate_instance[0].id
-  watsonx_orchestrate_crn           = var.existing_watsonx_orchestrate_instance_crn != null ? data.ibm_resource_instance.existing_orchestrate_instance[0].crn : ibm_resource_instance.watsonx_orchestrate_instance[0].crn
-  watsonx_orchestrate_guid          = var.existing_watsonx_orchestrate_instance_crn != null ? data.ibm_resource_instance.existing_orchestrate_instance[0].guid : ibm_resource_instance.watsonx_orchestrate_instance[0].guid
-  watsonx_orchestrate_name          = var.existing_watsonx_orchestrate_instance_crn != null ? data.ibm_resource_instance.existing_orchestrate_instance[0].resource_name : ibm_resource_instance.watsonx_orchestrate_instance[0].resource_name
-  watsonx_orchestrate_plan_id       = var.existing_watsonx_orchestrate_instance_crn != null ? null : ibm_resource_instance.watsonx_orchestrate_instance[0].resource_plan_id
-  raw_crn                           = "crn:v1:bluemix:public:watsonx-orchestrate:${var.region}:a/${local.account_id}:${local.watsonx_orchestrate_guid}::"
+  account_id                  = var.existing_watsonx_orchestrate_instance_crn != null ? module.crn_parser[0].account_id : ibm_resource_instance.watsonx_orchestrate_instance[0].account_id
+  watsonx_orchestrate_id      = var.existing_watsonx_orchestrate_instance_crn != null ? data.ibm_resource_instance.existing_orchestrate_instance[0].id : ibm_resource_instance.watsonx_orchestrate_instance[0].id
+  watsonx_orchestrate_crn     = var.existing_watsonx_orchestrate_instance_crn != null ? data.ibm_resource_instance.existing_orchestrate_instance[0].crn : ibm_resource_instance.watsonx_orchestrate_instance[0].crn
+  watsonx_orchestrate_guid    = var.existing_watsonx_orchestrate_instance_crn != null ? data.ibm_resource_instance.existing_orchestrate_instance[0].guid : ibm_resource_instance.watsonx_orchestrate_instance[0].guid
+  watsonx_orchestrate_name    = var.existing_watsonx_orchestrate_instance_crn != null ? data.ibm_resource_instance.existing_orchestrate_instance[0].resource_name : ibm_resource_instance.watsonx_orchestrate_instance[0].resource_name
+  watsonx_orchestrate_plan_id = var.existing_watsonx_orchestrate_instance_crn != null ? null : ibm_resource_instance.watsonx_orchestrate_instance[0].resource_plan_id
+  raw_crn                     = "crn:v1:bluemix:public:watsonx-orchestrate:${var.region}:a/${local.account_id}:${local.watsonx_orchestrate_guid}::"
+  # Temporary workaround for issue 13340[https://github.ibm.com/GoldenEye/issues/issues/13340].
   watsonx_orchestrate_dashboard_url = "https://cloud.ibm.com/services/watsonx-orchestrate/${urlencode(local.raw_crn)}"
 }
 

--- a/main.tf
+++ b/main.tf
@@ -1,11 +1,13 @@
 locals {
-  account_id                        = var.existing_watsonx_orchestrate_instance_crn != null ? module.crn_parser[0].account_id : ibm_resource_instance.watsonx_orchestrate_instance[0].account_id
-  watsonx_orchestrate_id            = var.existing_watsonx_orchestrate_instance_crn != null ? data.ibm_resource_instance.existing_orchestrate_instance[0].id : ibm_resource_instance.watsonx_orchestrate_instance[0].id
-  watsonx_orchestrate_crn           = var.existing_watsonx_orchestrate_instance_crn != null ? data.ibm_resource_instance.existing_orchestrate_instance[0].crn : ibm_resource_instance.watsonx_orchestrate_instance[0].crn
-  watsonx_orchestrate_guid          = var.existing_watsonx_orchestrate_instance_crn != null ? data.ibm_resource_instance.existing_orchestrate_instance[0].guid : ibm_resource_instance.watsonx_orchestrate_instance[0].guid
-  watsonx_orchestrate_name          = var.existing_watsonx_orchestrate_instance_crn != null ? data.ibm_resource_instance.existing_orchestrate_instance[0].resource_name : ibm_resource_instance.watsonx_orchestrate_instance[0].resource_name
-  watsonx_orchestrate_plan_id       = var.existing_watsonx_orchestrate_instance_crn != null ? null : ibm_resource_instance.watsonx_orchestrate_instance[0].resource_plan_id
-  watsonx_orchestrate_dashboard_url = var.existing_watsonx_orchestrate_instance_crn != null ? null : ibm_resource_instance.watsonx_orchestrate_instance[0].dashboard_url
+  account_id                  = var.existing_watsonx_orchestrate_instance_crn != null ? module.crn_parser[0].account_id : ibm_resource_instance.watsonx_orchestrate_instance[0].account_id
+  watsonx_orchestrate_id      = var.existing_watsonx_orchestrate_instance_crn != null ? data.ibm_resource_instance.existing_orchestrate_instance[0].id : ibm_resource_instance.watsonx_orchestrate_instance[0].id
+  watsonx_orchestrate_crn     = var.existing_watsonx_orchestrate_instance_crn != null ? data.ibm_resource_instance.existing_orchestrate_instance[0].crn : ibm_resource_instance.watsonx_orchestrate_instance[0].crn
+  watsonx_orchestrate_guid    = var.existing_watsonx_orchestrate_instance_crn != null ? data.ibm_resource_instance.existing_orchestrate_instance[0].guid : ibm_resource_instance.watsonx_orchestrate_instance[0].guid
+  watsonx_orchestrate_name    = var.existing_watsonx_orchestrate_instance_crn != null ? data.ibm_resource_instance.existing_orchestrate_instance[0].resource_name : ibm_resource_instance.watsonx_orchestrate_instance[0].resource_name
+  watsonx_orchestrate_plan_id = var.existing_watsonx_orchestrate_instance_crn != null ? null : ibm_resource_instance.watsonx_orchestrate_instance[0].resource_plan_id
+  # watsonx_orchestrate_dashboard_url = var.existing_watsonx_orchestrate_instance_crn != null ? null : "https://cloud.ibm.com/services/watsonx-orchestrate/${urlencode(local.watsonx_orchestrate_crn)}?paneId=manage&new=true"
+  watsonx_orchestrate_dashboard_url = local.watsonx_orchestrate_crn != null ? "https://us-south.watson-orchestrate.cloud.ibm.com/home/ws?plan_id=${urlencode(local.watsonx_orchestrate_plan_id)}" : null
+
 }
 
 module "crn_parser" {

--- a/main.tf
+++ b/main.tf
@@ -1,11 +1,10 @@
 locals {
-  account_id                  = var.existing_watsonx_orchestrate_instance_crn != null ? module.crn_parser[0].account_id : ibm_resource_instance.watsonx_orchestrate_instance[0].account_id
-  watsonx_orchestrate_id      = var.existing_watsonx_orchestrate_instance_crn != null ? data.ibm_resource_instance.existing_orchestrate_instance[0].id : ibm_resource_instance.watsonx_orchestrate_instance[0].id
-  watsonx_orchestrate_crn     = var.existing_watsonx_orchestrate_instance_crn != null ? data.ibm_resource_instance.existing_orchestrate_instance[0].crn : ibm_resource_instance.watsonx_orchestrate_instance[0].crn
-  watsonx_orchestrate_guid    = var.existing_watsonx_orchestrate_instance_crn != null ? data.ibm_resource_instance.existing_orchestrate_instance[0].guid : ibm_resource_instance.watsonx_orchestrate_instance[0].guid
-  watsonx_orchestrate_name    = var.existing_watsonx_orchestrate_instance_crn != null ? data.ibm_resource_instance.existing_orchestrate_instance[0].resource_name : ibm_resource_instance.watsonx_orchestrate_instance[0].resource_name
-  watsonx_orchestrate_plan_id = var.existing_watsonx_orchestrate_instance_crn != null ? null : ibm_resource_instance.watsonx_orchestrate_instance[0].resource_plan_id
-  # watsonx_orchestrate_dashboard_url = var.existing_watsonx_orchestrate_instance_crn != null ? null : "https://cloud.ibm.com/services/watsonx-orchestrate/${urlencode(local.watsonx_orchestrate_crn)}?paneId=manage&new=true"
+  account_id                        = var.existing_watsonx_orchestrate_instance_crn != null ? module.crn_parser[0].account_id : ibm_resource_instance.watsonx_orchestrate_instance[0].account_id
+  watsonx_orchestrate_id            = var.existing_watsonx_orchestrate_instance_crn != null ? data.ibm_resource_instance.existing_orchestrate_instance[0].id : ibm_resource_instance.watsonx_orchestrate_instance[0].id
+  watsonx_orchestrate_crn           = var.existing_watsonx_orchestrate_instance_crn != null ? data.ibm_resource_instance.existing_orchestrate_instance[0].crn : ibm_resource_instance.watsonx_orchestrate_instance[0].crn
+  watsonx_orchestrate_guid          = var.existing_watsonx_orchestrate_instance_crn != null ? data.ibm_resource_instance.existing_orchestrate_instance[0].guid : ibm_resource_instance.watsonx_orchestrate_instance[0].guid
+  watsonx_orchestrate_name          = var.existing_watsonx_orchestrate_instance_crn != null ? data.ibm_resource_instance.existing_orchestrate_instance[0].resource_name : ibm_resource_instance.watsonx_orchestrate_instance[0].resource_name
+  watsonx_orchestrate_plan_id       = var.existing_watsonx_orchestrate_instance_crn != null ? null : ibm_resource_instance.watsonx_orchestrate_instance[0].resource_plan_id
   watsonx_orchestrate_dashboard_url = local.watsonx_orchestrate_crn != null ? "https://us-south.watson-orchestrate.cloud.ibm.com/home/ws?plan_id=${urlencode(local.watsonx_orchestrate_plan_id)}" : null
 
 }

--- a/main.tf
+++ b/main.tf
@@ -5,7 +5,8 @@ locals {
   watsonx_orchestrate_guid          = var.existing_watsonx_orchestrate_instance_crn != null ? data.ibm_resource_instance.existing_orchestrate_instance[0].guid : ibm_resource_instance.watsonx_orchestrate_instance[0].guid
   watsonx_orchestrate_name          = var.existing_watsonx_orchestrate_instance_crn != null ? data.ibm_resource_instance.existing_orchestrate_instance[0].resource_name : ibm_resource_instance.watsonx_orchestrate_instance[0].resource_name
   watsonx_orchestrate_plan_id       = var.existing_watsonx_orchestrate_instance_crn != null ? null : ibm_resource_instance.watsonx_orchestrate_instance[0].resource_plan_id
-  watsonx_orchestrate_dashboard_url = var.existing_watsonx_orchestrate_instance_crn != null ? null : "https://us-south.watson-orchestrate.cloud.ibm.com/home/ws?plan_id=${urlencode(local.watsonx_orchestrate_plan_id)}"
+  raw_crn                           = "crn:v1:bluemix:public:watsonx-orchestrate:${var.region}:a/${local.account_id}:${local.watsonx_orchestrate_guid}::"
+  watsonx_orchestrate_dashboard_url = "https://cloud.ibm.com/services/watsonx-orchestrate/${urlencode(local.raw_crn)}"
 }
 
 module "crn_parser" {

--- a/main.tf
+++ b/main.tf
@@ -1,13 +1,12 @@
 locals {
   account_id                  = var.existing_watsonx_orchestrate_instance_crn != null ? module.crn_parser[0].account_id : ibm_resource_instance.watsonx_orchestrate_instance[0].account_id
   watsonx_orchestrate_id      = var.existing_watsonx_orchestrate_instance_crn != null ? data.ibm_resource_instance.existing_orchestrate_instance[0].id : ibm_resource_instance.watsonx_orchestrate_instance[0].id
-  watsonx_orchestrate_crn     = var.existing_watsonx_orchestrate_instance_crn != null ? data.ibm_resource_instance.existing_orchestrate_instance[0].crn : ibm_resource_instance.watsonx_orchestrate_instance[0].crn
+  watsonx_orchestrate_crn     = var.existing_watsonx_orchestrate_instance_crn != null ? var.existing_watsonx_orchestrate_instance_crn : ibm_resource_instance.watsonx_orchestrate_instance[0].crn
   watsonx_orchestrate_guid    = var.existing_watsonx_orchestrate_instance_crn != null ? data.ibm_resource_instance.existing_orchestrate_instance[0].guid : ibm_resource_instance.watsonx_orchestrate_instance[0].guid
   watsonx_orchestrate_name    = var.existing_watsonx_orchestrate_instance_crn != null ? data.ibm_resource_instance.existing_orchestrate_instance[0].resource_name : ibm_resource_instance.watsonx_orchestrate_instance[0].resource_name
   watsonx_orchestrate_plan_id = var.existing_watsonx_orchestrate_instance_crn != null ? null : ibm_resource_instance.watsonx_orchestrate_instance[0].resource_plan_id
-  raw_crn                     = "crn:v1:bluemix:public:watsonx-orchestrate:${var.region}:a/${local.account_id}:${local.watsonx_orchestrate_guid}::"
   # Temporary workaround for issue 13340[https://github.ibm.com/GoldenEye/issues/issues/13340].
-  watsonx_orchestrate_dashboard_url = "https://cloud.ibm.com/services/watsonx-orchestrate/${urlencode(local.raw_crn)}"
+  watsonx_orchestrate_dashboard_url = "https://cloud.ibm.com/services/watsonx-orchestrate/${urlencode(local.watsonx_orchestrate_crn)}"
 }
 
 module "crn_parser" {


### PR DESCRIPTION
### Description

This PR introduces a temporary workaround to construct the `dashboard_url` values for Watsonx Orchestrate manually.
[Git issue](https://github.ibm.com/GoldenEye/issues/issues/13340)
### Release required?
<!--- Identify the type of release. For information about the changes in a semantic versioning release, see [Release versioning](https://terraform-ibm-modules.github.io/documentation/#/versioning). --->

- [ ] No release
- [x] Patch release (`x.x.X`)
- [ ] Minor release (`x.X.x`)
- [ ] Major release (`X.x.x`)

##### Release notes content

Dynamically generating the Watsonx Orchestrate dashboard URL using the known base URL  combined with the `watsonx_orchestrate_crn`.
### Run the pipeline

If the CI pipeline doesn't run when you create the PR, the PR requires a user with GitHub collaborators access to run the pipeline.

Run the CI pipeline when the PR is ready for review and you expect tests to pass. Add a comment to the PR with the following text:

```
/run pipeline
```

### Checklist for reviewers

- [ ] If relevant, a test for the change is included or updated with this PR.
- [ ] If relevant, documentation for the change is included or updated with this PR.

### For mergers

- Use a conventional commit message to set the release level. Follow the [guidelines](https://terraform-ibm-modules.github.io/documentation/#/merging.md).
- Include information that users need to know about the PR in the commit message. The commit message becomes part of the GitHub release notes.
- Use the **Squash and merge** option.
