### PR TITLE
feat: support for trial plan and support for new regions

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ statement instead the previous block.
 |------|-------------|------|---------|:--------:|
 | <a name="input_access_tags"></a> [access\_tags](#input\_access\_tags) | A list of access tags to apply to the watsonx Orchestrate instance. For more information, see https://cloud.ibm.com/docs/account?topic=account-access-tags-tutorial. | `list(string)` | `[]` | no |
 | <a name="input_existing_watsonx_orchestrate_instance_crn"></a> [existing\_watsonx\_orchestrate\_instance\_crn](#input\_existing\_watsonx\_orchestrate\_instance\_crn) | The CRN of an existing watsonx Orchestrate instance.If not provided, a new instance will be provisioned. | `string` | `null` | no |
-| <a name="input_plan"></a> [plan](#input\_plan) | The plan that is required to provision the watsonx Orchestrate instance. Possible values are: trial, essentials, standard. | `string` | `"trial"` | no |
+| <a name="input_plan"></a> [plan](#input\_plan) | The plan that is required to provision the watsonx Orchestrate instance. Possible values are: lite, essentials, standard. | `string` | `"lite"` | no |
 | <a name="input_region"></a> [region](#input\_region) | Region where the watsonx Orchestrate instance will be provisioned. Required if creating a new instance. | `string` | `"us-south"` | no |
 | <a name="input_resource_group_id"></a> [resource\_group\_id](#input\_resource\_group\_id) | The resource group ID where the watsonx Orchestrate instance will be grouped. Required when creating a new instance. | `string` | `null` | no |
 | <a name="input_resource_tags"></a> [resource\_tags](#input\_resource\_tags) | Optional list of tags to describe the watsonx Orchestrate instance created by the module. | `list(string)` | `[]` | no |

--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ statement instead the previous block.
 |------|-------------|------|---------|:--------:|
 | <a name="input_access_tags"></a> [access\_tags](#input\_access\_tags) | A list of access tags to apply to the watsonx Orchestrate instance. For more information, see https://cloud.ibm.com/docs/account?topic=account-access-tags-tutorial. | `list(string)` | `[]` | no |
 | <a name="input_existing_watsonx_orchestrate_instance_crn"></a> [existing\_watsonx\_orchestrate\_instance\_crn](#input\_existing\_watsonx\_orchestrate\_instance\_crn) | The CRN of an existing watsonx Orchestrate instance.If not provided, a new instance will be provisioned. | `string` | `null` | no |
-| <a name="input_plan"></a> [plan](#input\_plan) | The plan that is required to provision the watsonx Orchestrate instance. Possible values are: essentials, standard. | `string` | `"essentials"` | no |
+| <a name="input_plan"></a> [plan](#input\_plan) | The plan that is required to provision the watsonx Orchestrate instance. Possible values are: essentials, standard. | `string` | `"trial"` | no |
 | <a name="input_region"></a> [region](#input\_region) | Region where the watsonx Orchestrate instance will be provisioned. Required if creating a new instance. | `string` | `"us-south"` | no |
 | <a name="input_resource_group_id"></a> [resource\_group\_id](#input\_resource\_group\_id) | The resource group ID where the watsonx Orchestrate instance will be grouped. Required when creating a new instance. | `string` | `null` | no |
 | <a name="input_resource_tags"></a> [resource\_tags](#input\_resource\_tags) | Optional list of tags to describe the watsonx Orchestrate instance created by the module. | `list(string)` | `[]` | no |

--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ statement instead the previous block.
 |------|-------------|------|---------|:--------:|
 | <a name="input_access_tags"></a> [access\_tags](#input\_access\_tags) | A list of access tags to apply to the watsonx Orchestrate instance. For more information, see https://cloud.ibm.com/docs/account?topic=account-access-tags-tutorial. | `list(string)` | `[]` | no |
 | <a name="input_existing_watsonx_orchestrate_instance_crn"></a> [existing\_watsonx\_orchestrate\_instance\_crn](#input\_existing\_watsonx\_orchestrate\_instance\_crn) | The CRN of an existing watsonx Orchestrate instance.If not provided, a new instance will be provisioned. | `string` | `null` | no |
-| <a name="input_plan"></a> [plan](#input\_plan) | The plan that is required to provision the watsonx Orchestrate instance. Possible values are: essentials, standard. | `string` | `"trial"` | no |
+| <a name="input_plan"></a> [plan](#input\_plan) | The plan that is required to provision the watsonx Orchestrate instance. Possible values are: trial, essentials, standard. | `string` | `"trial"` | no |
 | <a name="input_region"></a> [region](#input\_region) | Region where the watsonx Orchestrate instance will be provisioned. Required if creating a new instance. | `string` | `"us-south"` | no |
 | <a name="input_resource_group_id"></a> [resource\_group\_id](#input\_resource\_group\_id) | The resource group ID where the watsonx Orchestrate instance will be grouped. Required when creating a new instance. | `string` | `null` | no |
 | <a name="input_resource_tags"></a> [resource\_tags](#input\_resource\_tags) | Optional list of tags to describe the watsonx Orchestrate instance created by the module. | `list(string)` | `[]` | no |

--- a/examples/basic/main.tf
+++ b/examples/basic/main.tf
@@ -19,7 +19,6 @@ module "watsonx_orchestrate" {
   region                   = var.region
   watsonx_orchestrate_name = "${var.prefix}-orchestrate"
   resource_group_id        = module.resource_group.resource_group_id
-  plan                     = "lite"
   resource_tags            = var.resource_tags
   access_tags              = var.access_tags
 }

--- a/examples/basic/main.tf
+++ b/examples/basic/main.tf
@@ -19,7 +19,7 @@ module "watsonx_orchestrate" {
   region                   = var.region
   watsonx_orchestrate_name = "${var.prefix}-orchestrate"
   resource_group_id        = module.resource_group.resource_group_id
-  plan                     = "essentials"
+  plan                     = "trial"
   resource_tags            = var.resource_tags
   access_tags              = var.access_tags
 }

--- a/examples/basic/main.tf
+++ b/examples/basic/main.tf
@@ -19,7 +19,7 @@ module "watsonx_orchestrate" {
   region                   = var.region
   watsonx_orchestrate_name = "${var.prefix}-orchestrate"
   resource_group_id        = module.resource_group.resource_group_id
-  plan                     = "trial"
+  plan                     = "lite"
   resource_tags            = var.resource_tags
   access_tags              = var.access_tags
 }

--- a/examples/basic/variables.tf
+++ b/examples/basic/variables.tf
@@ -23,6 +23,7 @@ variable "region" {
   description = "Region to provision all resources created by this example."
   default     = "us-south"
 }
+
 variable "resource_group" {
   type        = string
   description = "The name of an existing resource group to provision resources into. If not set a new resource group will be created using the prefix variable."

--- a/ibm_catalog.json
+++ b/ibm_catalog.json
@@ -148,10 +148,9 @@
             },
             {
               "key": "service_plan",
-              "default_value": "standard",
               "options": [
                 {
-                  "displayname": "Lite",
+                  "displayname": "Trial",
                   "value": "lite"
                 },
                 {

--- a/ibm_catalog.json
+++ b/ibm_catalog.json
@@ -99,6 +99,18 @@
                 {
                   "displayname": "London (eu-gb)",
                   "value": "eu-gb"
+                },
+                {
+                  "displayname": "Frankfurt (eu-de)",
+                  "value": "eu-de"
+                },
+                {
+                  "displayname": "Sydney (au-syd)",
+                  "value": "au-syd"
+                },
+                {
+                  "displayname": "Tokyo (jp-tok)",
+                  "value": "jp-tok"
                 }
               ]
             },
@@ -138,6 +150,10 @@
               "key": "service_plan",
               "default_value": "standard",
               "options": [
+                {
+                  "displayname": "Trial",
+                  "value": "trial"
+                },
                 {
                   "displayname": "Essentials",
                   "value": "essentials"

--- a/ibm_catalog.json
+++ b/ibm_catalog.json
@@ -151,8 +151,8 @@
               "default_value": "standard",
               "options": [
                 {
-                  "displayname": "Trial",
-                  "value": "trial"
+                  "displayname": "Lite",
+                  "value": "lite"
                 },
                 {
                   "displayname": "Essentials",

--- a/ibm_catalog.json
+++ b/ibm_catalog.json
@@ -86,7 +86,6 @@
             {
               "key": "region",
               "required": true,
-              "default_value": "us-south",
               "options": [
                 {
                   "displayname": "Dallas (us-south)",

--- a/solutions/fully-configurable/variables.tf
+++ b/solutions/fully-configurable/variables.tf
@@ -45,7 +45,7 @@ variable "region" {
 
 variable "service_plan" {
   type        = string
-  description = "The plan that is required to provision the watsonx Orchestrate instance. Possible values are: lite, essentials, standard. [Learn more](https://www.ibm.com/products/watsonx-orchestrate/pricing)."
+  description = "The plan that is required to provision the watsonx Orchestrate instance. Possible values are: lite, essentials, standard. [Learn more](https://cloud.ibm.com/catalog/services/watsonx-orchestrate)."
   default     = "essentials"
 }
 

--- a/solutions/fully-configurable/variables.tf
+++ b/solutions/fully-configurable/variables.tf
@@ -45,7 +45,7 @@ variable "region" {
 
 variable "service_plan" {
   type        = string
-  description = "The plan that is required to provision the watsonx Orchestrate instance. Possible values are: trial, essentials, standard. [Learn more](https://www.ibm.com/products/watsonx-orchestrate/pricing)."
+  description = "The plan that is required to provision the watsonx Orchestrate instance. Possible values are: lite, essentials, standard. [Learn more](https://www.ibm.com/products/watsonx-orchestrate/pricing)."
   default     = "essentials"
 }
 

--- a/solutions/fully-configurable/variables.tf
+++ b/solutions/fully-configurable/variables.tf
@@ -45,8 +45,8 @@ variable "region" {
 
 variable "service_plan" {
   type        = string
-  description = "The plan that is required to provision the watsonx Orchestrate instance. Possible values are: essentials, standard. [Learn more](https://www.ibm.com/products/watsonx-orchestrate/pricing)."
-  default     = "essentials"
+  description = "The plan that is required to provision the watsonx Orchestrate instance. Possible values are: trial, essentials, standard. [Learn more](https://www.ibm.com/products/watsonx-orchestrate/pricing)."
+  default     = "trial"
 }
 
 variable "resource_tags" {

--- a/solutions/fully-configurable/variables.tf
+++ b/solutions/fully-configurable/variables.tf
@@ -46,7 +46,7 @@ variable "region" {
 variable "service_plan" {
   type        = string
   description = "The plan that is required to provision the watsonx Orchestrate instance. Possible values are: trial, essentials, standard. [Learn more](https://www.ibm.com/products/watsonx-orchestrate/pricing)."
-  default     = "trial"
+  default     = "essentials"
 }
 
 variable "resource_tags" {

--- a/tests/existing-resources/main.tf
+++ b/tests/existing-resources/main.tf
@@ -18,7 +18,7 @@ module "watsonx_orchestrate" {
   source                   = "../../"
   region                   = var.region
   watsonx_orchestrate_name = "${var.prefix}-wx-orchestrate"
-  plan                     = "essentials"
+  plan                     = var.plan
   resource_group_id        = module.resource_group.resource_group_id
   resource_tags            = var.resource_tags
   access_tags              = var.access_tags

--- a/tests/existing-resources/variables.tf
+++ b/tests/existing-resources/variables.tf
@@ -24,6 +24,12 @@ variable "region" {
   default     = "us-south"
 }
 
+variable "plan" {
+  description = "The plan that is required to provision the watsonx Orchestrate instance. Possible values are: lite, essentials, standard."
+  type        = string
+  default     = "lite"
+}
+
 variable "resource_group" {
   type        = string
   description = "The name of an existing resource group to provision resources into. If not set a new resource group will be created using the prefix variable."

--- a/tests/pr_test.go
+++ b/tests/pr_test.go
@@ -37,8 +37,11 @@ var sharedInfoSvc *cloudinfo.CloudInfoService
 // Current supported regions
 var validRegions = []string{
 	"us-south",
-	"eu-gb",
 	"ca-tor",
+	"eu-gb",
+	"eu-de",
+	"au-syd",
+	"jp-tok",
 }
 
 func TestMain(m *testing.M) {
@@ -159,7 +162,7 @@ func TestRunStandardSolution(t *testing.T) {
 	})
 
 	options.TerraformVars = map[string]interface{}{
-		"service_plan":                 "essentials",
+		"service_plan":                 "trial",
 		"provider_visibility":          "public",
 		"existing_resource_group_name": resourceGroup,
 		"prefix":                       options.Prefix,
@@ -183,7 +186,7 @@ func TestRunStandardUpgradeSolution(t *testing.T) {
 	})
 
 	options.TerraformVars = map[string]interface{}{
-		"service_plan":                 "essentials",
+		"service_plan":                 "trial",
 		"provider_visibility":          "public",
 		"existing_resource_group_name": resourceGroup,
 		"prefix":                       options.Prefix,

--- a/tests/pr_test.go
+++ b/tests/pr_test.go
@@ -104,6 +104,7 @@ func TestRunExistingResourcesExample(t *testing.T) {
 		Vars: map[string]interface{}{
 			"prefix":        prefix,
 			"resource_tags": tags,
+			"plan":          "essentials",
 			"access_tags":   permanentResources["accessTags"],
 			"region":        validRegions[rand.Intn(len(validRegions))],
 		},

--- a/tests/pr_test.go
+++ b/tests/pr_test.go
@@ -162,7 +162,7 @@ func TestRunStandardSolution(t *testing.T) {
 	})
 
 	options.TerraformVars = map[string]interface{}{
-		"service_plan":                 "trial",
+		"service_plan":                 "lite",
 		"provider_visibility":          "public",
 		"existing_resource_group_name": resourceGroup,
 		"prefix":                       options.Prefix,
@@ -186,7 +186,7 @@ func TestRunStandardUpgradeSolution(t *testing.T) {
 	})
 
 	options.TerraformVars = map[string]interface{}{
-		"service_plan":                 "trial",
+		"service_plan":                 "lite",
 		"provider_visibility":          "public",
 		"existing_resource_group_name": resourceGroup,
 		"prefix":                       options.Prefix,

--- a/tests/pr_test.go
+++ b/tests/pr_test.go
@@ -162,7 +162,7 @@ func TestRunStandardSolution(t *testing.T) {
 	})
 
 	options.TerraformVars = map[string]interface{}{
-		"service_plan":                 "lite",
+		"service_plan":                 "essentials",
 		"provider_visibility":          "public",
 		"existing_resource_group_name": resourceGroup,
 		"prefix":                       options.Prefix,

--- a/variables.tf
+++ b/variables.tf
@@ -76,7 +76,7 @@ variable "plan" {
   }
   validation {
     condition = anytrue([
-      var.plan == "lite",
+      var.plan == "lite", # This refers to the Trial plan.
       var.plan == "essentials",
       var.plan == "standard",
     ]) || var.existing_watsonx_orchestrate_instance_crn != null

--- a/variables.tf
+++ b/variables.tf
@@ -67,19 +67,19 @@ variable "existing_watsonx_orchestrate_instance_crn" {
 }
 
 variable "plan" {
-  description = "The plan that is required to provision the watsonx Orchestrate instance. Possible values are: trial, essentials, standard."
+  description = "The plan that is required to provision the watsonx Orchestrate instance. Possible values are: lite, essentials, standard."
   type        = string
-  default     = "trial"
+  default     = "lite"
   validation {
     condition     = var.existing_watsonx_orchestrate_instance_crn != null || var.plan != null
     error_message = "watsonx Orchestrate plan must be provided when creating a new instance."
   }
   validation {
     condition = anytrue([
-      var.plan == "trial",
+      var.plan == "lite",
       var.plan == "essentials",
       var.plan == "standard",
     ]) || var.existing_watsonx_orchestrate_instance_crn != null
-    error_message = "A new watsonx Orchestrate instance requires a 'trial', 'essentials' or 'standard' plan."
+    error_message = "A new watsonx Orchestrate instance requires a 'lite', 'essentials' or 'standard' plan."
   }
 }

--- a/variables.tf
+++ b/variables.tf
@@ -67,7 +67,7 @@ variable "existing_watsonx_orchestrate_instance_crn" {
 }
 
 variable "plan" {
-  description = "The plan that is required to provision the watsonx Orchestrate instance. Possible values are: essentials, standard."
+  description = "The plan that is required to provision the watsonx Orchestrate instance. Possible values are: trial, essentials, standard."
   type        = string
   default     = "trial"
   validation {

--- a/variables.tf
+++ b/variables.tf
@@ -20,10 +20,13 @@ variable "region" {
   validation {
     condition = var.existing_watsonx_orchestrate_instance_crn != null || anytrue([
       var.region == "us-south",
+      var.region == "ca-tor",
       var.region == "eu-gb",
-      var.region == "ca-tor"
+      var.region == "eu-de",
+      var.region == "au-syd",
+      var.region == "jp-tok"
     ])
-    error_message = "Region must be specified and set to one of the permitted values ('ca-tor', 'eu-gb', 'us-south') when provisioning a new instance."
+    error_message = "Region must be specified and set to one of the permitted values ('us-south', 'ca-tor', 'eu-gb', 'eu-de', 'au-syd', 'jp-tok') when provisioning a new instance."
   }
 }
 
@@ -66,16 +69,17 @@ variable "existing_watsonx_orchestrate_instance_crn" {
 variable "plan" {
   description = "The plan that is required to provision the watsonx Orchestrate instance. Possible values are: essentials, standard."
   type        = string
-  default     = "essentials"
+  default     = "trial"
   validation {
     condition     = var.existing_watsonx_orchestrate_instance_crn != null || var.plan != null
     error_message = "watsonx Orchestrate plan must be provided when creating a new instance."
   }
   validation {
     condition = anytrue([
+      var.plan == "trial",
       var.plan == "essentials",
       var.plan == "standard",
     ]) || var.existing_watsonx_orchestrate_instance_crn != null
-    error_message = "A new watsonx Orchestrate instance requires a 'essentials' or 'standard' plan."
+    error_message = "A new watsonx Orchestrate instance requires a 'trial', 'essentials' or 'standard' plan."
   }
 }


### PR DESCRIPTION
### Description

https://github.com/terraform-ibm-modules/terraform-ibm-watsonx-orchestrate/issues/75

### Release required?
<!--- Identify the type of release. For information about the changes in a semantic versioning release, see [Release versioning](https://terraform-ibm-modules.github.io/documentation/#/versioning). --->

- [ ] No release
- [ ] Patch release (`x.x.X`)
- [X] Minor release (`x.X.x`)
- [ ] Major release (`X.x.x`)

##### Release notes content

This release adds - 

- Support for the trial plan for watsonx-orchestrate instance.
- Support for new regions ('eu-de', 'jp-tok', 'au-syd')

### Run the pipeline

If the CI pipeline doesn't run when you create the PR, the PR requires a user with GitHub collaborators access to run the pipeline.

Run the CI pipeline when the PR is ready for review and you expect tests to pass. Add a comment to the PR with the following text:

```
/run pipeline
```

### Checklist for reviewers

- [ ] If relevant, a test for the change is included or updated with this PR.
- [ ] If relevant, documentation for the change is included or updated with this PR.

### For mergers

- Use a conventional commit message to set the release level. Follow the [guidelines](https://terraform-ibm-modules.github.io/documentation/#/merging.md).
- Include information that users need to know about the PR in the commit message. The commit message becomes part of the GitHub release notes.
- Use the **Squash and merge** option.
